### PR TITLE
fix(config): add ID to Pier config

### DIFF
--- a/cmd/goduck/pier.go
+++ b/cmd/goduck/pier.go
@@ -89,6 +89,11 @@ var pierCMD = &cli.Command{
 					Value: ".",
 					Usage: "where to put the generated configuration files",
 				},
+				&cli.IntFlag{
+					Name:  "ID",
+					Value: 0,
+					Usage: "specify Pier's ID which is in [0,9], cannot exist 2 or more Piers with same ID in one OS",
+				},
 			},
 			Action: generatePierConfig,
 		},

--- a/config/pier/api
+++ b/config/pier/api
@@ -1,1 +1,1 @@
-http://localhost:8080/v1/
+http://localhost:808{{.Id}}/v1/

--- a/config/pier/pier.toml
+++ b/config/pier/pier.toml
@@ -1,7 +1,7 @@
 title = "Pier"
 
 [port]
-pprof = 44555
+pprof = 4455{{.Id}}
 
 [log]
 level = "debug"


### PR DESCRIPTION
GoDuck can generate different port number based on different ID, thus one OS can run more than one Pier.