### PR TITLE
fix(cmd/goduck/deploy): fix the bug in bitxhub remote deployment

### DIFF
--- a/cmd/goduck/deploy.go
+++ b/cmd/goduck/deploy.go
@@ -1,16 +1,19 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
-	"github.com/codeskyblue/go-sh"
-	"github.com/meshplus/bitxhub-kit/fileutil"
-	"github.com/meshplus/goduck/internal/download"
-	"github.com/meshplus/goduck/internal/repo"
-	"github.com/urfave/cli/v2"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/codeskyblue/go-sh"
+	"github.com/fatih/color"
+	"github.com/meshplus/bitxhub-kit/fileutil"
+	"github.com/meshplus/goduck/internal/download"
+	"github.com/meshplus/goduck/internal/repo"
+	"github.com/urfave/cli/v2"
 )
 
 func deployCMD() *cli.Command {
@@ -50,15 +53,29 @@ func deployBitXHub(ctx *cli.Context) error {
 		return err
 	}
 
+	username := ctx.String("username")
+	version := ctx.String("version")
+
+	data, err := ioutil.ReadFile(filepath.Join(repoRoot, "release.json"))
+	if err != nil {
+		return err
+	}
+
+	var release *Release
+	if err := json.Unmarshal(data, &release); err != nil {
+		return err
+	}
+
+	if !AdjustVersion(version, release.Bitxhub) {
+		return fmt.Errorf("unsupport bitxhub verison")
+	}
+
 	target := filepath.Join(repoRoot, "config")
 
 	err = os.MkdirAll(target, os.ModePerm)
 	if err != nil {
 		return err
 	}
-
-	username := ctx.String("username")
-	version := ctx.String("version")
 
 	dir, err := ioutil.TempDir("", "bitxhub")
 	if err != nil {
@@ -84,44 +101,46 @@ func deployBitXHub(ctx *cli.Context) error {
 	filePath := filepath.Join(binPath, filename)
 
 	if !fileutil.Exist(filePath) {
-		err = download.Download(binPath, "https://github.com/meshplus/bitxhub/releases/download/v1.1.0-rc1/bitxhub_linux-amd64_v1.1.0-rc1.tar.gz")
+		url := fmt.Sprintf("https://github.com/meshplus/bitxhub/releases/download/%s/bitxhub_linux-amd64_%s.tar.gz", version, version)
+		err = download.Download(binPath, url)
 		if err != nil {
 			return err
 		}
 	}
 
-	//for _, ip := range ips {
-	//	err = sh.Command("ssh-copy-id", fmt.Sprintf("%s@%s", username, ip)).Run()
-	//	if err != nil {
-	//		return err
-	//	}
-	//}
-
 	for idx, ip := range ips {
-		fmt.Printf("Operating at node%d\n", idx+1)
+		color.Blue("====> Operating at node%d\n", idx+1)
 		who := fmt.Sprintf("%s@%s", username, ip)
 		target := fmt.Sprintf("%s:~/", who)
-		err = sh.Command("scp", filePath, target).
-			Command("ssh", who, fmt.Sprintf("`tar xzf %s`", filename)).
+
+		err = sh.
 			Command("scp", "-r",
 				fmt.Sprintf("%s/node%d", dir, idx+1),
 				fmt.Sprintf("%s%s", target, "build")).
-			Command("ssh", who, "`export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/build`").
-			Command("ssh", who, fmt.Sprintf("`mkdir -p build/node%d/plugins`", idx+1)).
-			Command("ssh", who, fmt.Sprintf("`cp build/raft.so build/node%d/plugins`", idx+1)).Run()
+			Command("scp", filePath, target).
+			Run()
+		if err != nil {
+			return err
+		}
+
+		err = sh.
+			Command("ssh", who, "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/build").
+			Command("ssh", who, fmt.Sprintf("tar xzf %s && mkdir -p build/node%d/plugins && cp build/raft.so build/node%d/plugins", filename, idx+1, idx+1)).Run()
 		if err != nil {
 			return err
 		}
 	}
 
-	fmt.Println("Run")
+	color.Blue("====> Run\n")
 	for idx, ip := range ips {
 		who := fmt.Sprintf("%s@%s", username, ip)
-		err = sh.Command("ssh", who, "`export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/build`").
+		err = sh.Command("ssh", who, "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/build").
 			Command("ssh", who,
-				fmt.Sprintf("`cd build && nohup ./bitxhub --repo node%d start &`", idx+1)).Run()
+				fmt.Sprintf("cd ~/build && nohup bitxhub --repo node%d start &", idx+1)).Run()
 		if err != nil {
 			return err
+		} else {
+			color.Green("====> Start bitxhub node%d successful\n", idx+1)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/elastic/gosigar v0.10.5 // indirect
 	github.com/ethereum/go-ethereum v1.9.13
+	github.com/fatih/color v1.7.0
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
 	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08 // indirect
 	github.com/gobuffalo/packd v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,7 @@ github.com/ethereum/go-ethereum v1.9.13 h1:rOPqjSngvs1VSYH2H+PMPiWt4VEulvNRbFgqi
 github.com/ethereum/go-ethereum v1.9.13/go.mod h1:qwN9d1GLyDh0N7Ab8bMGd0H9knaji2jOBm2RrMGjXls=
 github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239/go.mod h1:Gdwt2ce0yfBxPvZrHkprdPPTTS3N5rwmLE8T22KBXlw=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 h1:FtmdgXiUlNeRsoNMFlKLDt+S+6hbjVMEW6RGQ7aUf7c=


### PR DESCRIPTION
1. Because the original command was executed in parallel, there was some errors that can not found some files;
2. Add a judgment on whether the release is supported before deployment;
3. Make the installation package download according to the version;
4. Add some information printing.