### PR TITLE
fix(scripts/info):fix the bug about info command

### DIFF
--- a/scripts/info.sh
+++ b/scripts/info.sh
@@ -7,6 +7,8 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 NC='\033[0m'
+BITXHUB_PATH=${CURRENT_PATH}/bitxhub
+PIER_PATH=${CURRENT_PATH}/pier
 
 function print_blue() {
   printf "${BLUE}%s${NC}\n" "$1"
@@ -26,19 +28,19 @@ function printHelp() {
 }
 
 function showBxhInfo() {
-  if [ -d ${CURRENT_PATH}/nodeSolo ]; then
+  if [ -d ${BITXHUB_PATH}/nodeSolo ]; then
     if [ "$(ps aux | grep bitxhub | grep -v grep | grep -v info)" ]; then
       print_blue "======> Show address of solo bitxhub node started in binary"
-      bitxhub key address --path ${CURRENT_PATH}/nodeSolo/certs/node.priv
+      bitxhub key address --path ${BITXHUB_PATH}/nodeSolo/certs/node.priv
     fi
   fi
 
-  nodes=$(ls ${CURRENT_PATH} | grep node | grep -v nodeSolo || true)
+  nodes=$(ls ${BITXHUB_PATH} | grep node | grep -v nodeSolo || true)
   if [ -n "$nodes" ]; then
     if [ "$(ps aux | grep bitxhub | grep -v grep | grep -v info)" ]; then
       print_blue "======> Show address of each bitxhub node started in binary"
       for n in $nodes ; do
-        bitxhub key address --path ${CURRENT_PATH}/$n/certs/node.priv
+        bitxhub key address --path ${BITXHUB_PATH}/$n/certs/node.priv
       done
     fi
   fi
@@ -79,17 +81,17 @@ function showPierInfo() {
     done
   fi
 
-  if [ -d ${CURRENT_PATH}/.pier_ethereum ]; then
+  if [ -d ${PIER_PATH}/.pier_ethereum ]; then
     if [ "$(ps aux | grep pier | grep -v grep | grep -v info)" ]; then
       print_blue "======> info about piers of ethereum in binary"
-      ${CURRENT_PATH}/bin/pier --repo=${CURRENT_PATH}/.pier_ethereum id
+      cat ${CURRENT_PATH}/pier/pier-ethereum.addr
     fi
   fi
 
-  if [ -d ${CURRENT_PATH}/.pier_fabric ]; then
+  if [ -d ${PIER_PATH}/.pier_fabric ]; then
     if [ "$(ps aux | grep pier | grep -v grep | grep -v info)" ]; then
       print_blue "======> info about piers of fabric in binary"
-      ${CURRENT_PATH}/bin/pier --repo=${CURRENT_PATH}/.pier_fabric id
+      cat ${CURRENT_PATH}/pier/pier-fabric.addr
     fi
   fi
 }


### PR DESCRIPTION
1. Fix the wrong configuration path for pier and bitxhub;
2. Change the print mode for pier info.