### PR TITLE
fix(scripts): replace the method used to determine whether the pier binary component is started in the INFO command with a more accurate one

### DIFF
--- a/scripts/info.sh
+++ b/scripts/info.sh
@@ -75,14 +75,13 @@ function showPierInfo() {
     cat ${CURRENT_PATH}/pier/pier-fabric-docker.addr
   fi
 
-  if [ -d ${PIER_PATH}/.pier_ethereum ]; then
+  if [ -e ${PIER_PATH}/pier-ethereum.pid ]; then
     if [ "$(ps aux | grep pier | grep -v grep | grep -v info)" ]; then
       print_blue "======> info about piers of ethereum in binary"
       cat ${CURRENT_PATH}/pier/pier-ethereum-binary.addr
     fi
   fi
-
-  if [ -d ${PIER_PATH}/.pier_fabric ]; then
+  if [ -e ${PIER_PATH}/pier-fabric.pid ]; then
     if [ "$(ps aux | grep pier | grep -v grep | grep -v info)" ]; then
       print_blue "======> info about piers of fabric in binary"
       cat ${CURRENT_PATH}/pier/pier-fabric-binary.addr

--- a/scripts/run_pier.sh
+++ b/scripts/run_pier.sh
@@ -251,10 +251,10 @@ function pier_binary_up() {
   nohup "${PIER_PATH}"/pier --repo "${START_PATH}" start >/dev/null 2>&1 &
   PID=$!
 
-  sleep 1
+  sleep 10
   if [ -n "$(ps -p ${PID} -o pid=)" ]; then
     print_green "===> Start pier successfully!!!"
-    echo $! >"${CURRENT_PATH}/pier/pier-${MODE}.pid"
+    echo ${PID} >"${CURRENT_PATH}/pier/pier-${MODE}.pid"
     echo `"${PIER_PATH}"/pier --repo "${START_PATH}" id` >"${CURRENT_PATH}/pier/pier-${MODE}-binary.addr"
   else
     print_red "===> Start pier fail"


### PR DESCRIPTION
1. Replace the method used to determine whether the PIER binary component is started in the INFO command with a more accurate one.
2. The interval time between pier component start and check was extended according to actual conditions.