### PR TITLE
fix(*): fix bugs about pier config

### DIFF
--- a/cmd/goduck/deploy.go
+++ b/cmd/goduck/deploy.go
@@ -318,7 +318,7 @@ func deployPier(ctx *cli.Context) error {
 	cryptoPath := ctx.String("cryptoPath")
 	appchainIP := ctx.String("appchainIP")
 	appchainAddr := ctx.String("appchainAddr")
-	appchainPorts := ctx.String("appchainPorts")
+	appchainPorts := strings.Replace(ctx.String("appchainPorts"), " ", "", -1)
 	appchainContractAddr := ctx.String("contractAddr")
 	version := ctx.String("version")
 

--- a/cmd/goduck/pier.go
+++ b/cmd/goduck/pier.go
@@ -313,7 +313,7 @@ func pierRegister(ctx *cli.Context) error {
 	overwrite := ctx.String("overwrite")
 	appchainIP := ctx.String("appchainIP")
 	appchainAddr := ctx.String("appchainAddr")
-	appchainPorts := ctx.String("appchainPorts")
+	appchainPorts := strings.Replace(ctx.String("appchainPorts"), " ", "", -1)
 	appchainContractAddr := ctx.String("contractAddr")
 
 	appPorts, appchainAddr, err := getAppchainParams(chainType, appchainIP, appchainPorts, appchainAddr, cryptoPath)
@@ -364,7 +364,7 @@ func pierStart(ctx *cli.Context) error {
 	overwrite := ctx.String("overwrite")
 	appchainIP := ctx.String("appchainIP")
 	appchainAddr := ctx.String("appchainAddr")
-	appchainPorts := ctx.String("appchainPorts")
+	appchainPorts := strings.Replace(ctx.String("appchainPorts"), " ", "", -1)
 	appchainContractAddr := ctx.String("contractAddr")
 	pierRepo := ctx.String("pierRepo")
 
@@ -506,7 +506,7 @@ func generatePierConfig(ctx *cli.Context) error {
 	cryptoPath := ctx.String("cryptoPath")
 	version := ctx.String("version")
 	appchainAddr := ctx.String("appchainAddr")
-	appchainPorts := ctx.String("appchainPorts")
+	appchainPorts := strings.Replace(ctx.String("appchainPorts"), " ", "", -1)
 	appchainContractAddr := ctx.String("contractAddr")
 
 	appPorts, appchainAddr, err := getAppchainParams(appchainType, appchainIP, appchainPorts, appchainAddr, cryptoPath)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -21,6 +21,7 @@ const (
 	InfoScript       = "info.sh"
 	Prometheus       = "prometheus.sh"
 	TlsCerts         = "certs"
+	TmpPath          = "tmp"
 
 	LinuxWasmLibUrl = "https://raw.githubusercontent.com/meshplus/bitxhub/master/build/libwasmer.so"
 	MacOSWasmLibUrl = "https://raw.githubusercontent.com/meshplus/bitxhub/master/build/libwasmer.dylib"

--- a/scripts/run_pier.sh
+++ b/scripts/run_pier.sh
@@ -179,7 +179,11 @@ function appchain_register() {
 }
 
 function rule_deploy() {
-  "${PIER_PATH}"/pier --repo "${PIERREPO}" rule deploy --path "${PIERREPO}"/$1/validating.wasm
+  if [ "${SYSTEM}" == "linux" ]; then
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PIER_PATH} && "${PIER_PATH}"/pier --repo "${PIERREPO}" rule deploy --path "${PIERREPO}"/$1/validating.wasm
+  elif [ "${SYSTEM}" == "darwin" ]; then
+    "${PIER_PATH}"/pier --repo "${PIERREPO}" rule deploy --path "${PIERREPO}"/$1/validating.wasm
+  fi
 }
 
 function pier_docker_up() {


### PR DESCRIPTION
1. Copy the CA certificate when generating the PIER configuration file, in case the user needs it later;
2. Use a timestamp when naming the intermediate directory of the generated configuration file to prevent duplication of names;
3. When PIER is deployed in Linux system, the specification of parameter LD_LIBRARY_PATH is added to prevent the path from being found.